### PR TITLE
Implemented option to change between the two gamemodes, conditional r…

### DIFF
--- a/app/create-room/page.tsx
+++ b/app/create-room/page.tsx
@@ -5,6 +5,7 @@ import {
   ArrowLeftOutlined,
   TrophyOutlined,
   ThunderboltFilled,
+  ThunderboltOutlined,
   CodeFilled,
   TrophyFilled,
   OrderedListOutlined,
@@ -46,7 +47,7 @@ export default function CreateRoomPage() {
 
   const [language, setLanguage] = useState("PYTHON");
   const [difficulty, setDifficulty] = useState("EASY");
-  const [mode, setMode] = useState("RACE");
+  const [mode, setMode] = useState("SPRINT_ARCADE");
   const [numProblems, setNumProblems] = useState(3);
   const [isLoading, setIsLoading] = useState(true);
   const [isAuthorized, setIsAuthorized] = useState(false);
@@ -201,15 +202,25 @@ export default function CreateRoomPage() {
             </h3>
             <div className={styles.optionsRow}>
               <div
-                className={`${styles.optionCard} ${styles.orangeHover} ${
-                  mode === "RACE" ? styles.selectedOrange : ""
-                }`}
-                onClick={() => setMode("RACE")}
+                className={`${styles.optionCard} ${styles.orangeHover} ${mode === "SPRINT_ARCADE" ? styles.selectedOrange : ""
+                  }`}
+                onClick={() => setMode("SPRINT_ARCADE")}
               >
                 <TrophyOutlined className={styles.gameModeIcon} />
                 <div>
-                  <p className={styles.optionName}>Race</p>
-                  <p className={styles.optionDesc}>First to solve all of the problems wins the game</p>
+                  <p className={styles.optionName}>Sprint Arcade</p>
+                  <p className={styles.optionDesc}>Race with coins, items, and sabotage</p>
+                </div>
+              </div>
+              <div
+                className={`${styles.optionCard} ${styles.orangeHover} ${mode === "SPRINT_CLASSIC" ? styles.selectedOrange : ""
+                  }`}
+                onClick={() => setMode("SPRINT_CLASSIC")}
+              >
+                <ThunderboltOutlined className={styles.gameModeIcon} />
+                <div>
+                  <p className={styles.optionName}>Sprint Classic</p>
+                  <p className={styles.optionDesc}>Pure 1v1 coding race. No items, no distractions</p>
                 </div>
               </div>
             </div>

--- a/app/games/[gameSessionId]/_types.ts
+++ b/app/games/[gameSessionId]/_types.ts
@@ -11,6 +11,7 @@ export interface GameRoundData {
     outputFormat: string;
     constraints: string;
     gameLanguage: string;
+    gameMode?: string;  
     opponentName?: string;
     playerAvatarId?: number;
     opponentAvatarId?: number;

--- a/app/games/[gameSessionId]/page.tsx
+++ b/app/games/[gameSessionId]/page.tsx
@@ -65,6 +65,7 @@ export default function GamePage() {
   const [runResult, setRunResult] = useState<ExecutionResult | null>(null);
   const [submitResult, setSubmitResult] = useState<ExecutionResult | null>(null);
   const [coinBalance, setCoinBalance] = useState<number>(0);
+  const [gameMode, setGameMode] = useState<string>("SPRINT_ARCADE");
 
   const me = players[String(userId)];
   const allPlayers = Object.entries(players);
@@ -82,6 +83,8 @@ export default function GamePage() {
 
   const fetchCoinBalance = async () => {
     if (!userId || !token) return;
+    const currentMode = localStorage.getItem("roomMode") ?? "SPRINT_ARCADE";
+    if (currentMode !== "SPRINT_ARCADE") return;
     try {
       const res = await fetch(`${getApiDomain()}/users/${userId}`, { headers: { token } });
       const data = await res.json();
@@ -115,6 +118,8 @@ export default function GamePage() {
       });
       const lang = (data.gameLanguage ?? "python").toLowerCase();
       setLanguage(lang);
+      const storedMode = localStorage.getItem("roomMode") ?? "SPRINT_ARCADE";
+      setGameMode(storedMode);
       setCode(lang === "java" ? javaStarter : pythonStarter);
       setProblem({
         id: data.problemId,
@@ -303,7 +308,7 @@ export default function GamePage() {
 
   // BUY ITEM
   const handleBuyItem = async (itemId: string, enumValue: string): Promise<boolean> => {
-    if (!token || playerSessionId == null) return false;
+    if (!token || playerSessionId == null || gameMode !== "SPRINT_ARCADE") return false;
     try {
       const response = await fetch(`${getApiDomain()}/games/${gameSessionId}/sabotage`, {
         method: "POST",
@@ -358,7 +363,7 @@ export default function GamePage() {
       )}
 
       {/* SABOTAGE NOTIFICATION */}
-      {sabotageNotification && (() => {
+      {gameMode === "SPRINT_ARCADE" && sabotageNotification && (() => {
         const effect = EFFECT_DISPLAY[sabotageNotification];
         return (
           <div style={{
@@ -441,7 +446,9 @@ export default function GamePage() {
         {/* LEFT COLUMN */}
         <div style={{ display: "flex", flexDirection: "column", gap: "16px", flex: 1, minWidth: 0 }}>
           <ProblemPanel problem={problem} language={language} timeLeft={timeLeft} />
-          <ItemShop coinBalance={coinBalance} onBuyItem={handleBuyItem} />
+          {gameMode === "SPRINT_ARCADE" && (
+            <ItemShop coinBalance={coinBalance} onBuyItem={handleBuyItem} />
+          )}
         </div>
 
         <CodeEditorPanel

--- a/app/rooms/[roomId]/page.tsx
+++ b/app/rooms/[roomId]/page.tsx
@@ -34,7 +34,7 @@ interface ChatMessage {
 }
 
 const formatEnum = (value: string) =>
-  value.charAt(0).toUpperCase() + value.slice(1).toLowerCase();
+  value.split("_").map(w => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase()).join(" ");
 
 const fadeOutAudio = (audio: HTMLAudioElement, durationMs: number, onComplete?: () => void) => {
   const steps = 30;
@@ -170,6 +170,7 @@ export default function LobbyPage() {
       if (typeof window !== "undefined") {
         localStorage.setItem("roomLanguage", (data.gameLanguage ?? "PYTHON").toLowerCase());
         localStorage.setItem("roomDifficulty", (data.gameDifficulty ?? "EASY"));
+        localStorage.setItem("roomMode", (data.gameMode ?? "SPRINT_ARCADE"));
       }
 
       const host = await fetchUsername(data.hostUserId);

--- a/app/rooms/page.tsx
+++ b/app/rooms/page.tsx
@@ -27,7 +27,7 @@ interface RoomData {
 }
 
 const formatEnum = (value: string) =>
-  value.charAt(0).toUpperCase() + value.slice(1).toLowerCase();
+  value.split("_").map(w => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase()).join(" ");
 
 export default function RoomsPage() {
   const router = useRouter();


### PR DESCRIPTION
…ender regarding shop and gamemode

app/create-room/page.tsx

The default mode changes from "RACE" to "SPRINT_ARCADE". 
Two modes to choose "SPRINT_ARCADE" and "SPRINT_CLASSIC"

 app/rooms/[roomId]/page.tsx (lobby)

Updated the formatEnum helper to split on underscores so that "SPRINT_ARCADE" renders as "Sprint Arcade" instead of "Sprint_arcade". 

app/rooms/page.tsx (rooms list)
app/rooms/page.tsx (rooms list)

Same formatEnum fix as the lobby so mode tags in the room browser display correctly.

app/games/[gameSessionId]/_types.ts

gameMode is added as an optional field to the GameRoundData interface to keep the type accurate.

app/games/[gameSessionId]/page.tsx 

A gameMode state variable is added and populated from localStorage.getItem("roomMode") when the game loads. fetchCoinBalance is guarded to return early in Sprint Classic (reading localStorage directly to avoid timing issues on first render). handleBuyItem is guarded as a second line of defence. The <ItemShop> component is only rendered when gameMode === "SPRINT_ARCADE". The sabotage notification overlay is also gated on the same condition.