### PR TITLE
fix to race condition

### DIFF
--- a/app/games/[gameSessionId]/_components/GameOverScreen.tsx
+++ b/app/games/[gameSessionId]/_components/GameOverScreen.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import CodosseumLogo from "@/components/CodosseumLogo";
 import CodosseumAvatar from "@/components/CodosseumAvatar";
 import useLocalStorage from "@/hooks/useLocalStorage";
-import { getApiDomain } from "@/utils/domain";
 import styles from "@/styles/game.module.css";
 import resultStyles from "@/styles/results.module.css";
 import { GameEndDTO, PlayerGameSummaryDTO } from "../_types";
@@ -56,42 +55,28 @@ export default function GameOverScreen({
 }: GameOverScreenProps) {
   const router = useRouter();
   const { value: userId } = useLocalStorage("userid", "");
-  const { value: token } = useLocalStorage("token", "");
   const [expandedSolutions, setExpandedSolutions] = useState<Set<string>>(new Set());
-  const [myStats, setMyStats] = useState<UserStats | null>(null);
-  const [opponentStats, setOpponentStats] = useState<UserStats | null>(null);
 
   const myUserIdNum = userId ? Number(userId) : null;
-  const opponentUserId = gameEndData?.playerScores?.find(p => p.userId !== myUserIdNum)?.userId ?? null;
 
-  const parseStats = (data: Record<string, number>): UserStats => {
-    const wins = data.winCount ?? 0;
-    const draws = data.drawCount ?? 0;
-    const gamesPlayed = data.totalGamesPlayed ?? 0;
-    return {
-      wins,
-      losses: gamesPlayed - wins - draws,
-      draws,
-      gamesPlayed,
-      winRate: data.winRatePercentage != null ? Math.round(data.winRatePercentage) : 0,
-    };
-  };
+  const myPlayerScore = gameEndData?.playerScores?.find(p => p.userId === myUserIdNum);
+  const opponentPlayerScore = gameEndData?.playerScores?.find(p => p.userId !== myUserIdNum);
 
-  useEffect(() => {
-    if (!token) return;
-    if (myUserIdNum) {
-      fetch(`${getApiDomain()}/users/${myUserIdNum}`, { headers: { token } })
-        .then(r => r.ok ? r.json() : null)
-        .then(data => { if (data) setMyStats(parseStats(data)); })
-        .catch(() => {});
-    }
-    if (opponentUserId) {
-      fetch(`${getApiDomain()}/users/${opponentUserId}`, { headers: { token } })
-        .then(r => r.ok ? r.json() : null)
-        .then(data => { if (data) setOpponentStats(parseStats(data)); })
-        .catch(() => {});
-    }
-  }, [myUserIdNum, opponentUserId, token]);
+  const myStats: UserStats | null = myPlayerScore ? {
+    wins: myPlayerScore.winCount,
+    draws: myPlayerScore.drawCount,
+    gamesPlayed: myPlayerScore.totalGamesPlayed,
+    losses: myPlayerScore.totalGamesPlayed - myPlayerScore.winCount - myPlayerScore.drawCount,
+    winRate: Math.round(myPlayerScore.winRatePercentage),
+  } : null;
+
+  const opponentStats: UserStats | null = opponentPlayerScore ? {
+    wins: opponentPlayerScore.winCount,
+    draws: opponentPlayerScore.drawCount,
+    gamesPlayed: opponentPlayerScore.totalGamesPlayed,
+    losses: opponentPlayerScore.totalGamesPlayed - opponentPlayerScore.winCount - opponentPlayerScore.drawCount,
+    winRate: Math.round(opponentPlayerScore.winRatePercentage),
+  } : null;
 
   const toggleSolution = (id: string) => {
     setExpandedSolutions(prev => {

--- a/app/games/[gameSessionId]/_types.ts
+++ b/app/games/[gameSessionId]/_types.ts
@@ -47,6 +47,11 @@ export interface GameRoundData {
     userId: number;
     username: string;
     score: number;
+    problemsSolved: number;
+    totalGamesPlayed: number;
+    winCount: number;
+    drawCount: number;
+    winRatePercentage: number;
   }
   
   export interface GameEndDTO {


### PR DESCRIPTION
Fix game-end stats race condition

  Stats on the result screen were read via a separate /users/{id} fetch that could arrive before the backend transaction committed, causing the current
   player to see stale totalGamesPlayed.

  Fix: embed post-game stats directly in GameEndDTO.playerScores (built after the stats update loop) and read them on the frontend from the WebSocket
  payload instead of fetching.